### PR TITLE
Add Check by Methods and Remove Check isRunningOnEmulator by default

### DIFF
--- a/src/android/de/cyberkatze/iroot/CordovaActions.java
+++ b/src/android/de/cyberkatze/iroot/CordovaActions.java
@@ -8,7 +8,34 @@ public class CordovaActions {
     public enum Action {
 
         ACTION_IS_ROOTED("isRooted"),
-        ACTION_IS_ROOTED_WITH_BUSY_BOX("isRootedWithBusyBox");
+        ACTION_IS_ROOTED_WITH_BUSY_BOX("isRootedWithBusyBox"),
+        ACTION_DETECTROOTMANAGEMENTAPPS("detectRootManagementApps"),
+        ACTION_DETECTPOTENTIALLYDANGEROUSAPPS("detectPotentiallyDangerousApps"),
+        ACTION_DETECTTESTKEYS("detectTestKeys"),
+        ACTION_CHECKFORBUSYBOXBINARY("checkForBusyBoxBinary"),
+        ACTION_CHECKFORSUBINARY("checkForSuBinary"),
+        ACTION_CHECKSUEXISTS("checkSuExists"),
+        ACTION_CHECKFORRWPATHS("checkForRWPaths"),
+        ACTION_CHECKFORDANGEROUSPROPS("checkForDangerousProps"),
+        ACTION_CHECKFORROOTNATIVE("checkForRootNative"),
+        ACTION_DETECTROOTCLOAKINGAPPS("detectRootCloakingApps"),
+        ACTION_ISSELINUXFLAGINENABLED("isSelinuxFlagInEnabled"),
+        ACTION_ISEXISTBUILDTAGS("isExistBuildTags"),
+        ACTION_DOESSUPERUSERAPKEXIST("doesSuperuserApkExist"),
+        ACTION_ISEXISTSUPATH("isExistSUPath"),
+        ACTION_CHECKDIRPERMISSIONS("checkDirPermissions"),
+        ACTION_CHECKEXECUTINGCOMMANDS("checkExecutingCommands"),
+        ACTION_CHECKINSTALLEDPACKAGES("checkInstalledPackages"),
+        ACTION_CHECKFOROVERTHEAIRCERTIFICATES("checkforOverTheAirCertificates"),
+        ACTION_ISRUNNINGONEMULATOR("isRunningOnEmulator"),
+        ACTION_SIMPLECHECKEMULATOR("simpleCheckEmulator"),
+        ACTION_SIMPLECHECKSDKBF86("simpleCheckSDKBF86"),
+        ACTION_SIMPLECHECKQRREFPH("simpleCheckQRREFPH"),
+        ACTION_SIMPLECHECKBUILD("simpleCheckBuild"),
+        ACTION_CHECKGENYMOTION("checkGenymotion"),
+        ACTION_CHECKGENERIC("checkGeneric"),
+        ACTION_CHECKGOOGLESDK("checkGoogleSDK"),
+        ACTION_TOGETDEVICEINFO("togetDeviceInfo");
 
         private final String name;
 

--- a/src/android/de/cyberkatze/iroot/CordovaActions.java
+++ b/src/android/de/cyberkatze/iroot/CordovaActions.java
@@ -35,7 +35,9 @@ public class CordovaActions {
         ACTION_CHECKGENYMOTION("checkGenymotion"),
         ACTION_CHECKGENERIC("checkGeneric"),
         ACTION_CHECKGOOGLESDK("checkGoogleSDK"),
-        ACTION_TOGETDEVICEINFO("togetDeviceInfo");
+        ACTION_TOGETDEVICEINFO("togetDeviceInfo"),
+        ACTION_IS_ROOTED_WITH_EMULATOR("isRootedWithEmulator"),
+        ACTION_IS_ROOTED_WITH_BUSY_BOX_WITH_EMULATOR("isRootedWithBusyBoxWithEmulator");
 
         private final String name;
 

--- a/src/android/de/cyberkatze/iroot/IRoot.java
+++ b/src/android/de/cyberkatze/iroot/IRoot.java
@@ -77,6 +77,42 @@ public class IRoot extends CordovaPlugin {
                 });
 
                 return true;
+            case ACTION_IS_ROOTED_WITH_EMULATOR:
+                cordova.getThreadPool().execute(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        PluginResult result;
+
+                        try {
+                            result = checkIsRootedWithEmulator(args, callbackContext);
+                        } catch (Exception error) {
+                            result = new PluginResult(PluginResult.Status.ERROR, error.toString());
+                        }
+
+                        callbackContext.sendPluginResult(result);
+                    }
+                });
+
+                return true;
+            case ACTION_IS_ROOTED_WITH_BUSY_BOX_WITH_EMULATOR:
+                cordova.getThreadPool().execute(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        PluginResult result;
+
+                        try {
+                            result = checkIsRootedWithBusyBoxWithEmulator(args, callbackContext);
+                        } catch (Exception error) {
+                            result = new PluginResult(PluginResult.Status.ERROR, error.toString());
+                        }
+
+                        callbackContext.sendPluginResult(result);
+                    }
+                });
+
+                return true;
             case ACTION_DETECTROOTMANAGEMENTAPPS:
             case ACTION_DETECTPOTENTIALLYDANGEROUSAPPS:
             case ACTION_DETECTTESTKEYS:
@@ -242,7 +278,7 @@ public class IRoot extends CordovaPlugin {
 
 
     /**
-     * Check with rootBeer without BusyBox.
+     * Check with rootBeer with BusyBox and with internal checks.
      */
     private PluginResult checkIsRootedWithBusyBox(final JSONArray args, final CallbackContext callbackContext) {
         try {
@@ -260,6 +296,52 @@ public class IRoot extends CordovaPlugin {
             return new PluginResult(Status.OK, isRooted);
         } catch (Exception error) {
             return Utils.getPluginResultError("checkIsRootedWithBusyBox", error);
+        }
+    }
+
+    /**
+     * Check with rootBeer and with internal checks and with isRunningOnEmulator
+     */
+     private PluginResult checkIsRootedWithEmulator(final JSONArray args, final CallbackContext callbackContext) {
+         try {
+             Context context = this.cordova.getActivity().getApplicationContext();
+             RootBeer rootBeer = new RootBeer(context);
+
+             boolean checkRootBeer = rootBeer.isRooted();
+             boolean checkInternal = this.internalRootDetection.isRootedWithEmulator(context);
+
+             LOG.d(Constants.LOG_TAG, "[checkIsRootedWithEmulator] checkRootBeer: " + checkRootBeer);
+             LOG.d(Constants.LOG_TAG, "[checkIsRootedWithEmulator] checkInternal: " + checkInternal);
+
+             boolean isRooted = checkRootBeer || checkInternal;
+             // boolean isRooted = checkRootBeer;
+
+             return new PluginResult(Status.OK, isRooted);
+         } catch (Exception error) {
+             return Utils.getPluginResultError("checkIsRootedWithEmulator", error);
+         }
+     }
+
+
+    /**
+     * Check with rootBeer with BusyBox and with internal checks and with isRunningOnEmulator
+     */
+    private PluginResult checkIsRootedWithBusyBoxWithEmulator(final JSONArray args, final CallbackContext callbackContext) {
+        try {
+            Context context = this.cordova.getActivity().getApplicationContext();
+            RootBeer rootBeer = new RootBeer(context);
+
+            boolean checkRootBeer = rootBeer.isRootedWithBusyBoxCheck();
+            boolean checkInternal = this.internalRootDetection.isRootedWithEmulator(context);
+
+            LOG.d(Constants.LOG_TAG, "[checkIsRootedWithBusyBoxWithEmulator] checkRootBeer: " + checkRootBeer);
+            LOG.d(Constants.LOG_TAG, "[checkIsRootedWithBusyBoxWithEmulator] checkInternal: " + checkInternal);
+
+            boolean isRooted = checkRootBeer || checkInternal;
+
+            return new PluginResult(Status.OK, isRooted);
+        } catch (Exception error) {
+            return Utils.getPluginResultError("checkIsRootedWithBusyBoxWithEmulator", error);
         }
     }
 

--- a/src/android/de/cyberkatze/iroot/IRoot.java
+++ b/src/android/de/cyberkatze/iroot/IRoot.java
@@ -10,6 +10,7 @@ import org.apache.cordova.LOG;
 import org.apache.cordova.PluginResult;
 import org.apache.cordova.PluginResult.Status;
 import org.json.JSONArray;
+import org.json.JSONObject;
 import org.json.JSONException;
 
 /**
@@ -76,6 +77,67 @@ public class IRoot extends CordovaPlugin {
                 });
 
                 return true;
+            case ACTION_DETECTROOTMANAGEMENTAPPS:
+            case ACTION_DETECTPOTENTIALLYDANGEROUSAPPS:
+            case ACTION_DETECTTESTKEYS:
+            case ACTION_CHECKFORBUSYBOXBINARY:
+            case ACTION_CHECKFORSUBINARY:
+            case ACTION_CHECKSUEXISTS:
+            case ACTION_CHECKFORRWPATHS:
+            case ACTION_CHECKFORDANGEROUSPROPS:
+            case ACTION_CHECKFORROOTNATIVE:
+            case ACTION_DETECTROOTCLOAKINGAPPS:
+            case ACTION_ISSELINUXFLAGINENABLED:
+            case ACTION_ISEXISTBUILDTAGS:
+            case ACTION_DOESSUPERUSERAPKEXIST:
+            case ACTION_ISEXISTSUPATH:
+            case ACTION_CHECKDIRPERMISSIONS:
+            case ACTION_CHECKEXECUTINGCOMMANDS:
+            case ACTION_CHECKINSTALLEDPACKAGES:
+            case ACTION_CHECKFOROVERTHEAIRCERTIFICATES:
+            case ACTION_ISRUNNINGONEMULATOR:
+            case ACTION_SIMPLECHECKEMULATOR:
+            case ACTION_SIMPLECHECKSDKBF86:
+            case ACTION_SIMPLECHECKQRREFPH:
+            case ACTION_SIMPLECHECKBUILD:
+            case ACTION_CHECKGENYMOTION:
+            case ACTION_CHECKGENERIC:
+            case ACTION_CHECKGOOGLESDK:
+                cordova.getThreadPool().execute(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        PluginResult result;
+
+                        try {
+                            result = WhatIsRooted(args, callbackContext, action);
+                        } catch (Exception error) {
+                            result = new PluginResult(PluginResult.Status.ERROR, error.toString());
+                        }
+
+                        callbackContext.sendPluginResult(result);
+                    }
+                });
+
+                return true;
+            case ACTION_TOGETDEVICEINFO:
+                cordova.getThreadPool().execute(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        PluginResult result;
+
+                        try {
+                            result = togetDeviceInfo(args, callbackContext);
+                        } catch (Exception error) {
+                            result = new PluginResult(PluginResult.Status.ERROR, error.toString());
+                        }
+
+                        callbackContext.sendPluginResult(result);
+                    }
+                });
+
+                return true;
             default:
                 cordova.getActivity().runOnUiThread(new Runnable() {
 
@@ -89,27 +151,95 @@ public class IRoot extends CordovaPlugin {
         }
     }
 
+
+    private PluginResult WhatIsRooted(final JSONArray args, final CallbackContext callbackContext, final String action) {
+        try {
+            Context context = this.cordova.getActivity().getApplicationContext();
+
+            RootBeer rootBeer = new RootBeer(context);
+            boolean WhatisRooted;
+            switch (action) {
+              case "detectRootManagementApps":
+                WhatisRooted = rootBeer.detectRootManagementApps();
+              break;
+              case "detectPotentiallyDangerousApps":
+                WhatisRooted = rootBeer.detectPotentiallyDangerousApps();
+              break;
+              case "detectTestKeys":
+                WhatisRooted = rootBeer.detectTestKeys();
+              break;
+              case "checkForBusyBoxBinary":
+                WhatisRooted = rootBeer.checkForBusyBoxBinary();
+              break;
+              case "checkForSuBinary":
+                WhatisRooted = rootBeer.checkForSuBinary();
+              break;
+              case "checkSuExists":
+                WhatisRooted = rootBeer.checkSuExists();
+              break;
+              case "checkForRWPaths":
+                WhatisRooted = rootBeer.checkForRWPaths();
+              break;
+              case "checkForDangerousProps":
+                WhatisRooted = rootBeer.checkForDangerousProps();
+              break;
+              case "checkForRootNative":
+                WhatisRooted = rootBeer.checkForRootNative();
+              break;
+              case "detectRootCloakingApps":
+                WhatisRooted = rootBeer.detectRootCloakingApps();
+              break;
+              case "isSelinuxFlagInEnabled":
+                WhatisRooted = Utils.isSelinuxFlagInEnabled();
+              break;
+              default: WhatisRooted = this.internalRootDetection.WhatisRooted(action, context);
+            }
+            boolean toWhatisRooted = WhatisRooted;
+            LOG.e(Constants.LOG_TAG, "[WhatIsRooted] "+action+": " + toWhatisRooted);
+
+            return new PluginResult(Status.OK, toWhatisRooted);
+        } catch (Exception error) {
+            return Utils.getPluginResultError("WhatIsRooted", error);
+        }
+    }
+
+    private PluginResult togetDeviceInfo(final JSONArray args, final CallbackContext callbackContext) {
+        try {
+            Context context = this.cordova.getActivity().getApplicationContext();
+
+            JSONObject MyDeviceInfo = this.internalRootDetection.togetDeviceInfo();
+
+            LOG.e(Constants.LOG_TAG, "[togetDeviceInfo] MyDeviceInfo: " + MyDeviceInfo.toString());
+
+            return new PluginResult(Status.OK, MyDeviceInfo);
+        } catch (Exception error) {
+            return Utils.getPluginResultError("MyDeviceInfo", error);
+        }
+    }
+
     /**
      * Check with rootBeer and with internal checks.
      */
-    private PluginResult checkIsRooted(final JSONArray args, final CallbackContext callbackContext) {
-        try {
-            Context context = this.cordova.getActivity().getApplicationContext();
-            RootBeer rootBeer = new RootBeer(context);
+     private PluginResult checkIsRooted(final JSONArray args, final CallbackContext callbackContext) {
+         try {
+             Context context = this.cordova.getActivity().getApplicationContext();
+             RootBeer rootBeer = new RootBeer(context);
 
-            boolean checkRootBeer = rootBeer.isRooted();
-            boolean checkInternal = this.internalRootDetection.isRooted(context);
+             boolean checkRootBeer = rootBeer.isRooted();
+             boolean checkInternal = this.internalRootDetection.isRooted(context);
 
-            LOG.d(Constants.LOG_TAG, "[checkIsRooted] checkRootBeer: " + checkRootBeer);
-            LOG.d(Constants.LOG_TAG, "[checkIsRooted] checkInternal: " + checkInternal);
+             LOG.d(Constants.LOG_TAG, "[checkIsRooted] checkRootBeer: " + checkRootBeer);
+             LOG.d(Constants.LOG_TAG, "[checkIsRooted] checkInternal: " + checkInternal);
 
-            boolean isRooted = checkRootBeer || checkInternal;
+             boolean isRooted = checkRootBeer || checkInternal;
+             // boolean isRooted = checkRootBeer;
 
-            return new PluginResult(Status.OK, isRooted);
-        } catch (Exception error) {
-            return Utils.getPluginResultError("checkIsRooted", error);
-        }
-    }
+             return new PluginResult(Status.OK, isRooted);
+         } catch (Exception error) {
+             return Utils.getPluginResultError("checkIsRooted", error);
+         }
+     }
+
 
     /**
      * Check with rootBeer without BusyBox.

--- a/src/android/de/cyberkatze/iroot/InternalRootDetection.java
+++ b/src/android/de/cyberkatze/iroot/InternalRootDetection.java
@@ -9,6 +9,8 @@ import org.apache.cordova.LOG;
 
 import java.io.File;
 import java.util.List;
+import org.json.JSONObject;
+import org.json.JSONException;
 
 public class InternalRootDetection {
 
@@ -38,6 +40,45 @@ public class InternalRootDetection {
         LOG.d(Constants.LOG_TAG, String.format("[checkDirPermissions] result: %s", result));
 
         return result;
+    }
+
+    public boolean WhatisRooted(final String action,final Context context) {
+      boolean restest = false;
+      switch (action) {
+        case "isExistBuildTags": restest = isExistBuildTags();
+        break;
+        case "doesSuperuserApkExist": restest = doesSuperuserApkExist();
+        break;
+        case "isExistSUPath": restest = isExistSUPath();
+        break;
+        case "checkDirPermissions": restest = checkDirPermissions();
+        break;
+        case "checkExecutingCommands": restest = checkExecutingCommands();
+        break;
+        case "checkInstalledPackages": restest = checkInstalledPackages(context);
+        break;
+        case "checkforOverTheAirCertificates": restest = checkforOverTheAirCertificates();
+        break;
+        case "isRunningOnEmulator": restest = isRunningOnEmulator();
+        break;
+        case "simpleCheckEmulator": restest = WhatisRunningOnEmulator(action);
+        break;
+        case "simpleCheckSDKBF86": restest = WhatisRunningOnEmulator(action);
+        break;
+        case "simpleCheckQRREFPH": restest = WhatisRunningOnEmulator(action);
+        break;
+        case "simpleCheckBuild": restest = WhatisRunningOnEmulator(action);
+        break;
+        case "checkGenymotion": restest = WhatisRunningOnEmulator(action);
+        break;
+        case "checkGeneric": restest = WhatisRunningOnEmulator(action);
+        break;
+        case "checkGoogleSDK": restest = WhatisRunningOnEmulator(action);
+        break;
+        default: LOG.e(Constants.LOG_TAG, String.format("[WhatisRooted] action: %s", action));
+      }
+      boolean result = restest;
+      return result;
     }
 
     /**
@@ -239,35 +280,73 @@ public class InternalRootDetection {
      * @see <a href="https://github.com/framgia/android-emulator-detector">android-emulator-detector</a>
      * @see <a href="https://github.com/testmandy/NativeAdLibrary-master/blob/68e1a972fc746a0b51395f813f5bcf32fd619376/library/src/main/java/me/dt/nativeadlibary/util/RootUtil.java#L59">testmandy RootUtil.java</a>
      */
-    public boolean isRunningOnEmulator() {
-        Utils.getDeviceInfo();
+     public boolean isRunningOnEmulator() {
+         Utils.getDeviceInfo();
+         boolean simpleCheck = Build.MODEL.contains("Emulator")
+             // ||Build.FINGERPRINT.startsWith("unknown") // Meizu Mx Pro will return unknown, so comment it!
+             || Build.MODEL.contains("Android SDK built for x86")
+             // || Build.BOARD.equals("QC_Reference_Phone") //bluestacks
+             || Build.HOST.startsWith("Build"); //MSI App Player
 
-        boolean simpleCheck = Build.MODEL.contains("Emulator")
-            // ||Build.FINGERPRINT.startsWith("unknown") // Meizu Mx Pro will return unknown, so comment it!
-            || Build.MODEL.contains("Android SDK built for x86")
-            || Build.BOARD.equals("QC_Reference_Phone") //bluestacks
-            || Build.HOST.startsWith("Build"); //MSI App Player
+         boolean checkGenymotion = Build.MANUFACTURER.contains("Genymotion");
+         boolean checkGeneric = Build.FINGERPRINT.startsWith("generic") || (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"));
+         boolean checkGoogleSDK = Build.MODEL.contains("google_sdk") || "google_sdk".equals(Build.PRODUCT);
 
-        boolean checkGenymotion = Build.MANUFACTURER.contains("Genymotion");
-        boolean checkGeneric = Build.FINGERPRINT.startsWith("generic") || (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"));
-        boolean checkGoogleSDK = Build.MODEL.contains("google_sdk") || "google_sdk".equals(Build.PRODUCT);
+         boolean result = simpleCheck || checkGenymotion || checkGeneric || checkGoogleSDK;
 
-        boolean result = simpleCheck || checkGenymotion || checkGeneric || checkGoogleSDK;
+         LOG.d(
+             Constants.LOG_TAG,
+             String.format(
+                 "[isRunningOnEmulator] result [%s] => [simpleCheck:%s][checkGenymotion:%s][checkGeneric:%s][checkGoogleSDK:%s]",
+                 result,
+                 simpleCheck,
+                 checkGenymotion,
+                 checkGeneric,
+                 checkGoogleSDK
+             )
+         );
 
-        LOG.d(
-            Constants.LOG_TAG,
-            String.format(
-                "[isRunningOnEmulator] result [%s] => [simpleCheck:%s][checkGenymotion:%s][checkGeneric:%s][checkGoogleSDK:%s]",
-                result,
-                simpleCheck,
-                checkGenymotion,
-                checkGeneric,
-                checkGoogleSDK
-            )
-        );
+         return result;
+     }
 
-        return result;
-    }
+     public boolean WhatisRunningOnEmulator(final String action) {
+
+         Utils.getDeviceInfo();
+         boolean result = false;
+
+         switch (action) {
+           case "simpleCheckEmulator": result = Build.MODEL.contains("Emulator");
+           break;
+           case "simpleCheckSDKBF86": result = Build.MODEL.contains("Android SDK built for x86");
+           break;
+           case "simpleCheckQRREFPH": result = Build.BOARD.equals("QC_Reference_Phone");
+           break;
+           case "simpleCheckBuild": result = Build.HOST.startsWith("Build");
+           break;
+           case "checkGenymotion": result = Build.MANUFACTURER.contains("Genymotion");
+           break;
+           case "checkGeneric": result = Build.FINGERPRINT.startsWith("generic") || (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"));
+           break;
+           case "checkGoogleSDK": result = Build.MODEL.contains("google_sdk") || "google_sdk".equals(Build.PRODUCT);
+           break;
+         }
+         return result;
+     }
+
+     public JSONObject togetDeviceInfo() throws JSONException {
+         Utils.getDeviceInfo();
+         JSONObject objBuild = new JSONObject();
+         objBuild.put("DEVICE",Build.DEVICE);
+         objBuild.put("MODEL",Build.MODEL);
+         objBuild.put("MANUFACTURER",Build.MANUFACTURER);
+         objBuild.put("BRAND",Build.BRAND);
+         objBuild.put("BOARD",Build.BOARD);
+         objBuild.put("HARDWARE",Build.HARDWARE);
+         objBuild.put("PRODUCT",Build.PRODUCT);
+         objBuild.put("FINGERPRINT",Build.FINGERPRINT);
+         objBuild.put("HOST",Build.HOST);
+         return objBuild;
+     }
 
     // TODO: https://github.com/tansiufang54/fncgss/blob/master/app/src/main/java/co/id/franknco/controller/RootUtil.java#L126
     //    private boolean checkServerSocket() {

--- a/src/android/de/cyberkatze/iroot/InternalRootDetection.java
+++ b/src/android/de/cyberkatze/iroot/InternalRootDetection.java
@@ -24,6 +24,32 @@ public class InternalRootDetection {
         boolean c5 = checkExecutingCommands();
         boolean c6 = checkInstalledPackages(context);
         boolean c7 = checkforOverTheAirCertificates();
+        // boolean c8 = isRunningOnEmulator();
+
+        LOG.d(Constants.LOG_TAG, "check c1 = isExistBuildTags: " + c1);
+        LOG.d(Constants.LOG_TAG, "check c2 = doesSuperuserApkExist: " + c2);
+        LOG.d(Constants.LOG_TAG, "check c3 = isExistSUPath: " + c3);
+        LOG.d(Constants.LOG_TAG, "check c4 = checkDirPermissions: " + c4);
+        LOG.d(Constants.LOG_TAG, "check c5 = checkExecutingCommands: " + c5);
+        LOG.d(Constants.LOG_TAG, "check c6 = checkInstalledPackages: " + c6);
+        LOG.d(Constants.LOG_TAG, "check c7 = checkforOverTheAirCertificates: " + c7);
+        // LOG.d(Constants.LOG_TAG, "check c8 = isRunningOnEmulator: " + c8);
+
+        boolean result = c1 || c2 || c3 || c4 || c5 || c6 || c7;
+
+        LOG.d(Constants.LOG_TAG, String.format("[checkDirPermissions] result: %s", result));
+
+        return result;
+    }
+
+    public boolean isRootedWithEmulator(final Context context) {
+        boolean c1 = isExistBuildTags();
+        boolean c2 = doesSuperuserApkExist();
+        boolean c3 = isExistSUPath();
+        boolean c4 = checkDirPermissions();
+        boolean c5 = checkExecutingCommands();
+        boolean c6 = checkInstalledPackages(context);
+        boolean c7 = checkforOverTheAirCertificates();
         boolean c8 = isRunningOnEmulator();
 
         LOG.d(Constants.LOG_TAG, "check c1 = isExistBuildTags: " + c1);
@@ -285,7 +311,7 @@ public class InternalRootDetection {
          boolean simpleCheck = Build.MODEL.contains("Emulator")
              // ||Build.FINGERPRINT.startsWith("unknown") // Meizu Mx Pro will return unknown, so comment it!
              || Build.MODEL.contains("Android SDK built for x86")
-             // || Build.BOARD.equals("QC_Reference_Phone") //bluestacks
+             || Build.BOARD.equals("QC_Reference_Phone") //bluestacks
              || Build.HOST.startsWith("Build"); //MSI App Player
 
          boolean checkGenymotion = Build.MANUFACTURER.contains("Genymotion");
@@ -345,6 +371,13 @@ public class InternalRootDetection {
          objBuild.put("PRODUCT",Build.PRODUCT);
          objBuild.put("FINGERPRINT",Build.FINGERPRINT);
          objBuild.put("HOST",Build.HOST);
+         // Add More info
+         objBuild.put("USER",Build.USER);
+         objBuild.put("OSNAME",System.getProperty("os.name"));
+         objBuild.put("OSVERSION",System.getProperty("os.version"));
+         objBuild.put("V.INCREMENTAL",Build.VERSION.INCREMENTAL);
+         objBuild.put("V.RELEASE",Build.VERSION.RELEASE);
+         objBuild.put("V.SDK_INT",Build.VERSION.SDK_INT);
          return objBuild;
      }
 

--- a/src/android/de/cyberkatze/iroot/Utils.java
+++ b/src/android/de/cyberkatze/iroot/Utils.java
@@ -8,8 +8,30 @@ import org.apache.cordova.PluginResult.Status;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.lang.reflect.Method;
 
 public class Utils {
+
+    private Utils() throws InstantiationException {
+          throw new InstantiationException("This class is not for instantiation");
+      }
+      /**
+       * In Development - an idea of ours was to check the if selinux is enforcing - this could be disabled for some rooting apps
+       * Checking for selinux mode
+       *
+       * @return true if selinux enabled
+       */
+      public static boolean isSelinuxFlagInEnabled() {
+          try {
+              Class<?> c = Class.forName("android.os.SystemProperties");
+              Method get = c.getMethod("get", String.class);
+              String selinux = (String) get.invoke(c, "ro.build.selinux");
+              return "1".equals(selinux);
+          } catch (Exception ignored) {
+
+          }
+          return false;
+      }
 
     /**
      * Helper function that logs the error and then calls the error callback.

--- a/www/iroot.js
+++ b/www/iroot.js
@@ -87,6 +87,12 @@ module.exports = {
     },
     togetDeviceInfo: function(onSuccess, onError) {
         exec(onSuccess, onError, 'IRoot', 'togetDeviceInfo', []);
+    },
+    isRootedWithEmulator: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'isRootedWithEmulator', []);
+    },
+    isRootedWithBusyBoxWithEmulator: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'isRootedWithBusyBoxWithEmulator', []);
     }
 
 };

--- a/www/iroot.js
+++ b/www/iroot.js
@@ -6,5 +6,87 @@ module.exports = {
     },
     isRootedWithBusyBox: function(onSuccess, onError) {
         exec(onSuccess, onError, 'IRoot', 'isRootedWithBusyBox', []);
+    },
+    detectRootManagementApps: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'detectRootManagementApps', []);
+    },
+    detectPotentiallyDangerousApps: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'detectPotentiallyDangerousApps', []);
+    },
+    detectTestKeys: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'detectTestKeys', []);
+    },
+    checkForBusyBoxBinary: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'checkForBusyBoxBinary', []);
+    },
+    checkForSuBinary: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'checkForSuBinary', []);
+    },
+    checkSuExists: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'checkSuExists', []);
+    },
+    checkForRWPaths: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'checkForRWPaths', []);
+    },
+    checkForDangerousProps: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'checkForDangerousProps', []);
+    },
+    checkForRootNative: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'checkForRootNative', []);
+    },
+    detectRootCloakingApps: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'detectRootCloakingApps', []);
+    },
+    isSelinuxFlagInEnabled: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'isSelinuxFlagInEnabled', []);
+    },
+    isExistBuildTags: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'isExistBuildTags', []);
+    },
+    doesSuperuserApkExist: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'doesSuperuserApkExist', []);
+    },
+    isExistSUPath: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'isExistSUPath', []);
+    },
+    checkDirPermissions: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'checkDirPermissions', []);
+    },
+    checkExecutingCommands: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'checkExecutingCommands', []);
+    },
+    checkInstalledPackages: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'checkInstalledPackages', []);
+    },
+    checkforOverTheAirCertificates: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'checkforOverTheAirCertificates', []);
+    },
+    isRunningOnEmulator: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'isRunningOnEmulator', []);
+    },
+    simpleCheckEmulator: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'simpleCheckEmulator', []);
+    },
+    simpleCheckSDKBF86: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'simpleCheckSDKBF86', []);
+    },
+    simpleCheckQRREFPH: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'simpleCheckQRREFPH', []);
+    },
+    simpleCheckBuild: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'simpleCheckBuild', []);
+    },
+    checkGenymotion: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'checkGenymotion', []);
+    },
+    checkGeneric: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'checkGeneric', []);
+    },
+    checkGoogleSDK: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'checkGoogleSDK', []);
+    },
+    togetDeviceInfo: function(onSuccess, onError) {
+        exec(onSuccess, onError, 'IRoot', 'togetDeviceInfo', []);
     }
+
 };


### PR DESCRIPTION
# Remove Check isRunningOnEmulator by default
Methods | Description
 --- | --- 
IRoot.isRooted | Check with rootBeer and with internal checks.
IRoot.isRootedWithBusyBox | Check with rootBeer with BusyBox and with internal checks.
IRoot.isRootedWithEmulator | Check with rootBeer and with internal checks and with **isRunningOnEmulator**
IRoot.isRootedWithBusyBoxWithEmulator | Check with rootBeer with BusyBox and with internal checks and with **isRunningOnEmulator**

## RootBear Library
Methods | Description | Boolean | Boolean
 --- | --- | --- | ---
IRoot.detectRootManagementApps | Root Management Apps | true | false
IRoot.detectPotentiallyDangerousApps | Potentially Dangerous Apps | true | false
IRoot.detectTestKeys | Test Keys | true | false
IRoot.checkForBusyBoxBinary | BusyBox Binary | true | false
IRoot.checkForSuBinary | Su Binary | true | false
IRoot.checkSuExists | Su Exists | true | false
IRoot.checkForRWPaths | RW Paths | true | false
IRoot.checkForDangerousProps | Dangerous Props | true | false
IRoot.checkForRootNative | Root Native | true | false
IRoot.detectRootCloakingApps | Root Cloaking Apps | true | false
IRoot.isSelinuxFlagInEnabled | Selinux Flag Enabled | true | false

## InternalRootDetection
Methods | Description | Boolean | Boolean
 --- | --- | --- | ---
IRoot.isExistBuildTags | Exist Build Tags | true | false
IRoot.doesSuperuserApkExist | Superuser Apk Exist | true | false
IRoot.isExistSUPath | Exist SU Path | true | false
IRoot.checkDirPermissions | Dir Permissions | true | false
IRoot.checkExecutingCommands | Executing Commands | true | false
IRoot.checkInstalledPackages | Installed Packages | true | false
IRoot.checkforOverTheAirCertificates | Over The Air Certificates | true | false
IRoot.isRunningOnEmulator | Running On Emulator | true | false

## isRunningOnEmulator
Methods | Description | Boolean | Boolean
 --- | --- | --- | ---
IRoot.simpleCheckEmulator | Build.MODEL.contains("Emulator") | true | false
IRoot.simpleCheckSDKBF86 | Build.MODEL.contains("Android SDK built for x86")| true | false
IRoot.simpleCheckQRREFPH | Build.BOARD.equals("QC_Reference_Phone") | true | false
IRoot.simpleCheckBuild | Build.HOST.startsWith("Build") | true | false
IRoot.checkGenymotion | Build.MANUFACTURER.contains("Genymotion") | true | false
IRoot.checkGeneric | Build.FINGERPRINT.startsWith("generic") \|\| (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic")) | true | false
IRoot.checkGoogleSDK | Build.MODEL.contains("google_sdk") \|\| "google_sdk".equals(Build.PRODUCT) | true | false

## getDeviceInfo
Methods | Objects
--- | --- 
IRoot.togetDeviceInfo | info

**Will return Device Info**
- Build.DEVICE
- Build.MODEL
- Build.MANUFACTURER
- Build.BRAND
- Build.BOARD
- Build.HARDWARE
- Build.PRODUCT
- Build.FINGERPRINT
- Build.HOST
- Build.USER
- System.getProperty("os.name")
- System.getProperty("os.version")
- Build.VERSION.INCREMENTAL
- Build.VERSION.RELEASE
- Build.VERSION.SDK_INT
```
{
   "DEVICE":"lavender",
   "MODEL":"Redmi Note 7",
   "MANUFACTURER":"Xiaomi",
   "BRAND":"xiaomi",
   "BOARD":"sdm660",
   "HARDWARE":"qcom",
   "PRODUCT":"lavender",
   "FINGERPRINT":"xiaomi\/lavender\/lavender:10\/QKQ1.190910.002\/V11.0.1.0.QFGMIXM:user\/release-keys",
   "HOST":"c4-miui-ota-bd05.bj",
   "USER":"builder",
   "OSNAME":"Linux",
   "OSVERSION":"4.4.192-perf+",
   "V.INCREMENTAL":"V11.0.1.0.QFGMIXM",
   "V.RELEASE":"10",
   "V.SDK_INT":29
}
```


